### PR TITLE
add new event features

### DIFF
--- a/besser/bot/core/session.py
+++ b/besser/bot/core/session.py
@@ -119,14 +119,6 @@ class Session:
             self.set("prev_state", self.current_state)
         self._current_state = transition.dest
         self._current_state.run(self)
-        # check whether automatic transition due to session param should take place
-        # TODO: maybe using the event_params to check the next transition is not the best way
-        for next_transition in self.current_state.transitions:
-            if "intent" in next_transition.event_params:
-                return
-            elif "var_name" in next_transition.event_params:
-                if next_transition.is_session_operation_matched(self):
-                    self.move(next_transition)
 
     def reply(self, message: str) -> None:
         """A bot message (usually a reply to a user message) is sent to the session platform to show it to the user.

--- a/besser/bot/core/state.py
+++ b/besser/bot/core/state.py
@@ -277,12 +277,7 @@ class State:
             logging.error("Something went wrong, no intent was predicted")
             return
         for transition in self.transitions:
-            if transition.is_intent_matched(session):
-                session.move(transition)
-                return
-            elif transition.is_session_operation_matched(session):
-                # TODO: Do we want this behaviour? We also would need to check generic events:
-                # elif transition.is_event_true()
+            if transition.is_event_true(session):
                 session.move(transition)
                 return
         if predicted_intent.intent == fallback_intent:

--- a/besser/bot/core/state.py
+++ b/besser/bot/core/state.py
@@ -308,12 +308,7 @@ class State:
             if next_transition.event == intent_matched:
                 # If the next transition is an intent_matched, we return to await the user message
                 return
-            elif next_transition.is_session_operation_matched(session):
-                # Check when_session_variable_operation_match_go_to transition
-                session.move(next_transition)
-                return
             elif next_transition.is_event_true(session):
-                # Check custom events transitions
                 session.move(next_transition)
                 return
 

--- a/besser/bot/exceptions/exceptions.py
+++ b/besser/bot/exceptions/exceptions.py
@@ -70,6 +70,14 @@ class BodySignatureError(Exception):
         super().__init__(message)
 
 
+class EventSignatureError(Exception):
+
+    def __init__(self, bot, event, event_template_signature, event_signature):
+        message = f"Expected parameters in event method '{event.__name__}' in bot " \
+                  f"'{bot.name}' are {event_template_signature}, got {event_signature} instead"
+        super().__init__(message)
+
+
 class DuplicatedAutoTransitionError(Exception):
 
     def __init__(self, bot, state):

--- a/besser/bot/library/event/event_library.py
+++ b/besser/bot/library/event/event_library.py
@@ -6,9 +6,12 @@ value, trigger the transitions.
 """
 
 import operator
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from besser.bot.core.intent.intent import Intent
+
+if TYPE_CHECKING:
+    from besser.bot.core.session import Session
 
 
 def auto() -> bool:
@@ -16,31 +19,36 @@ def auto() -> bool:
     return True
 
 
-def intent_matched(target_intent: Intent, matched_intent: Intent) -> bool:
+def intent_matched(session: 'Session', event_params: dict) -> bool:
     """
     This event checks if 2 intents are the same, used for intent matching checking.
 
     Args:
-        target_intent (Intent): the target intent
-        matched_intent (Intent): the intent that was matched from a user input
+        session (Session): the current user session
+        event_params (dict): the event parameters
 
     Returns:
         bool: True if the 2 intents are the same, false otherwise
     """
+    target_intent: Intent = event_params['intent']
+    matched_intent: Intent = session.predicted_intent.intent
     return target_intent.name == matched_intent.name
 
 
-def session_operation_matched(current_value: Any, operation: operator, target_value: Any) -> bool:
+def session_operation_matched(session: 'Session', event_params: dict) -> bool:
     """
     This event checks if for a specific comparison operation, using a stored session value
     and a given target value, returns true.
 
     Args:
-        current_value (Any): the stored value
-        operation (operator): the comparison operation to be used
-        target_value (Any): the target value to compare to
+        session (Session): the current user session
+        event_params (dict): the event parameters
 
     Returns:
         bool: True if the comparison operation of the given values returns true
     """
+    var_name: str = event_params['var_name']
+    target_value: Any = event_params['target']
+    operation: operator = event_params['operation']
+    current_value: Any = session.get(var_name)
     return operation(current_value, target_value)

--- a/besser/bot/library/event/event_template.py
+++ b/besser/bot/library/event/event_template.py
@@ -1,0 +1,12 @@
+from besser.bot.core.session import Session
+
+
+def event_template(session: Session, event_params: dict) -> bool:
+    """
+    Used as a reference for event method signatures.
+
+    Args:
+        session (Session): the current user session
+        event_params (dict): the event parameters
+    """
+    pass

--- a/docs/source/api/library.rst
+++ b/docs/source/api/library.rst
@@ -6,5 +6,6 @@ library
 
    library/base_entities
    library/event_library
+   library/event_template
    library/intent_library
    library/state_library

--- a/docs/source/api/library/event_template.rst
+++ b/docs/source/api/library/event_template.rst
@@ -1,0 +1,8 @@
+event_template
+==============
+
+.. automodule:: besser.bot.library.event.event_template
+   :members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
now, the standard signature for all events, including the predefined ones (intent_mathched and session_operation_matched) is composed by 2 args: session and event_params.

check event signature is correct in State.when_event_go_to. If an event doesn't have this signature, an exception EventSignatureError will be thrown

refactor State._check_next_auto_transition() to State._check_next_transition() (to check also other kinds of transitions that can be automatically followed after a state run, e.g., a session_operation_matched transition). This piece of code has been moved from Session.move()

added generated api docs for new module event_template